### PR TITLE
feat: update group image

### DIFF
--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -116,7 +116,8 @@ export class GroupController {
 
   @ApiOperation({
     summary: 'Upload a group image',
-    description: '그룹의 이미지를 업로드하는 API 입니다.',
+    description:
+      '그룹의 이미지를 업로드하는 API 입니다. 이미 존재하는 이미지는 덮어씌워집니다.',
   })
   @ApiConsumes('multipart/form-data')
   @ApiBody({

--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -271,7 +271,7 @@ export class GroupRepository {
       });
   }
 
-  async addGroupImage(imageKey: string, groupUuid: string): Promise<void> {
+  async updateGroupImage(imageKey: string, groupUuid: string): Promise<void> {
     await this.prismaService.group
       .update({
         where: {

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -96,11 +96,15 @@ export class GroupService {
       );
     }
 
-    const key = `group/${groupUuid}/image/${file.originalname}`;
+    const key = `group/${groupUuid}/image/${Date.now().toString()}-${file.originalname}`;
 
     await this.fileService.uploadFile(key, file);
 
-    await this.groupRepository.addGroupImage(key, groupUuid);
+    await this.groupRepository.updateGroupImage(key, groupUuid);
+
+    if (checkGroupExistence.profileImageKey) {
+      await this.fileService.deleteFile(checkGroupExistence.profileImageKey);
+    }
   }
 
   async deleteGroup(uuid: string, userUuid: string): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 이미지 업로드 시 기존 이미지가 덮어씌워짐을 명확히 하는 API 설명 업데이트.
	- 그룹 이미지를 업데이트하는 메서드 이름을 `addGroupImage`에서 `updateGroupImage`로 변경.
	- 동적 파일 이름을 사용하여 그룹 이미지 처리 방식 수정 및 이전 프로필 이미지 삭제 조건 추가.

- **버그 수정**
	- 그룹 이미지 업데이트 시의 메서드 및 처리 방식 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->