### PR TITLE
[FEATURE] notion 관련 api 만들기

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { GroupModule } from './group/group.module';
 import { RoleModule } from './role/role.module';
 import { RedisModule } from '@nestjs-modules/ioredis';
 import { ExternalModule } from './external/external.module';
+import { NotionModule } from './notion/notion.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ExternalModule } from './external/external.module';
     GroupModule,
     RoleModule,
     ExternalModule,
+    NotionModule,
   ],
   controllers: [AppController],
 })

--- a/src/notion/notion.controller.ts
+++ b/src/notion/notion.controller.ts
@@ -1,0 +1,36 @@
+import {
+  Controller,
+  Get,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { NotionService } from './notion.service';
+import {
+  ApiInternalServerErrorResponse,
+  ApiOAuth2,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GroupsGuard } from 'src/auth/guard/groups.guard';
+
+@ApiTags('notion')
+@ApiOAuth2(['openid', 'email', 'profile'])
+@Controller('notion')
+@UseGuards(GroupsGuard)
+@UsePipes(new ValidationPipe({ transform: true }))
+export class NotionController {
+  constructor(private readonly notionService: NotionService) {}
+
+  @ApiOperation({
+    summary: 'Get record map',
+    description: 'Notion pageId를 바탕으로 record map을 가져오는 API 입니다.',
+  })
+  @ApiOkResponse()
+  @ApiInternalServerErrorResponse()
+  @Get(':pageId')
+  async getRecordMap(pageId: string): Promise<JSON> {
+    return this.notionService.getRecordMap(pageId);
+  }
+}

--- a/src/notion/notion.module.ts
+++ b/src/notion/notion.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { NotionController } from './notion.controller';
+import { NotionService } from './notion.service';
+import { HttpModule } from '@nestjs/axios';
+import { AuthModule } from 'src/auth/auth.module';
+
+@Module({
+  imports: [HttpModule, AuthModule],
+  controllers: [NotionController],
+  providers: [NotionService],
+})
+export class NotionModule {}

--- a/src/notion/notion.service.ts
+++ b/src/notion/notion.service.ts
@@ -1,0 +1,37 @@
+import { HttpService } from '@nestjs/axios';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable()
+export class NotionService {
+  private readonly logger = new Logger(NotionService.name);
+  constructor(private readonly httpService: HttpService) {}
+
+  async getRecordMap(pageId: string): Promise<JSON> {
+    const response = await firstValueFrom(
+      this.httpService.post(
+        `https://www.notion.so/api/v3/loadPageChunk`,
+        {
+          pageId,
+          limit: 100,
+          cursor: { stack: [] },
+          chunkNumber: 0,
+          verticalColumns: false,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    ).catch((error) => {
+      this.logger.debug(error);
+      throw new InternalServerErrorException();
+    });
+    return response.data;
+  }
+}


### PR DESCRIPTION
Fixes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Notion 관련 HTTP 요청을 처리하는 `NotionController` 추가.
	- 특정 `pageId`에 대한 레코드 맵을 검색하는 GET 엔드포인트 제공.
	- Notion API와 상호 작용하는 `NotionService` 추가.
	- `NotionModule`을 통해 Notion 기능을 모듈화하여 통합.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->