### PR TITLE
[BUG] group profile url is not fully provided, it has just s3 key

### DIFF
--- a/src/external/dto/res/externalInfoRes.dto.ts
+++ b/src/external/dto/res/externalInfoRes.dto.ts
@@ -93,13 +93,26 @@ export class GroupWithRoleResDto implements GroupWithRole {
     return this.Role.map((role) => new RoleWithExternalResDto(role));
   }
 
+  @ApiProperty({
+    type: String,
+  })
+  @Expose()
+  get profileImageUrl(): string | null {
+    return this.profileImageKey
+      ? `${this.s3Url}/${this.profileImageKey}`
+      : null;
+  }
+
+  @Exclude()
+  s3Url: string;
+
   @Exclude()
   deletedAt: Date | null;
 
   @Exclude()
   Role: RoleWithExternalResDto[];
 
-  constructor(partial: Partial<GroupWithRole>) {
+  constructor(partial: Partial<GroupWithRole> & { s3Url: string }) {
     Object.assign(this, partial);
   }
 }

--- a/src/group/dto/res/ExpandedGroupRes.dto.ts
+++ b/src/group/dto/res/ExpandedGroupRes.dto.ts
@@ -69,7 +69,20 @@ export class ExpandedGroupResDto implements ExpandedGroup {
   @ApiProperty()
   profileImageKey: string | null;
 
-  constructor(partial: Partial<ExpandedGroup>) {
+  @ApiProperty({
+    type: String,
+  })
+  @Expose()
+  get profileImageUrl(): string | null {
+    return this.profileImageKey
+      ? `${this.s3Url}/${this.profileImageKey}`
+      : null;
+  }
+
+  @Exclude()
+  s3Url: string;
+
+  constructor(partial: Partial<ExpandedGroup> & { s3Url: string }) {
     Object.assign(this, partial);
   }
 }

--- a/src/group/dto/res/groupCreateRes.dto.ts
+++ b/src/group/dto/res/groupCreateRes.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Group } from '@prisma/client';
-import { Exclude } from 'class-transformer';
+import { Exclude, Expose } from 'class-transformer';
 
 export class GroupCreateResDto implements Group {
   @ApiProperty()
@@ -31,4 +31,21 @@ export class GroupCreateResDto implements Group {
 
   @ApiProperty()
   profileImageKey: string | null;
+
+  @ApiProperty({
+    type: String,
+  })
+  @Expose()
+  get profileImageUrl(): string | null {
+    return this.profileImageKey
+      ? `${this.s3Url}/${this.profileImageKey}`
+      : null;
+  }
+
+  @Exclude()
+  s3Url: string;
+
+  constructor(partial: Partial<Group> & { s3Url: string }) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/group/dto/res/groupRes.dto.ts
+++ b/src/group/dto/res/groupRes.dto.ts
@@ -33,10 +33,23 @@ export class GroupResDto implements Group {
     return this.verifiedAt !== null;
   }
 
+  @ApiProperty({
+    type: String,
+  })
+  @Expose()
+  get profileImageUrl(): string | null {
+    return this.profileImageKey
+      ? `${this.s3Url}/${this.profileImageKey}`
+      : null;
+  }
+
+  @Exclude()
+  s3Url: string;
+
   @Exclude()
   deletedAt: Date | null;
 
-  constructor(partial: Partial<GroupResDto>) {
+  constructor(partial: Partial<GroupResDto> & { s3Url: string }) {
     Object.assign(this, partial);
   }
 }

--- a/src/group/dto/res/invitationInfoRes.dto.ts
+++ b/src/group/dto/res/invitationInfoRes.dto.ts
@@ -40,10 +40,23 @@ export class InvitationInfoResDto implements ExpandedGroup {
     return this.President.email;
   }
 
+  @ApiProperty({
+    type: String,
+  })
+  @Expose()
+  get profileImageUrl(): string | null {
+    return this.profileImageKey
+      ? `${this.s3Url}/${this.profileImageKey}`
+      : null;
+  }
+
+  @Exclude()
+  s3Url: string;
+
   @ApiProperty()
   name: string;
 
-  constructor(partial: Partial<InvitationInfoResDto>) {
+  constructor(partial: Partial<InvitationInfoResDto> & { s3Url: string }) {
     Object.assign(this, partial);
   }
 }

--- a/src/group/group.controller.ts
+++ b/src/group/group.controller.ts
@@ -34,7 +34,6 @@ import { User } from '@prisma/client';
 import { GroupsGuard } from 'src/auth/guard/groups.guard';
 import {
   GroupListResDto,
-  GroupResDto,
   MemberListResDto,
   MemberResDto,
 } from './dto/res/groupRes.dto';
@@ -67,11 +66,7 @@ export class GroupController {
   @ApiInternalServerErrorResponse()
   @Get()
   async getGroupList(@GetUser() user: User): Promise<GroupListResDto> {
-    return {
-      list: (await this.groupService.getGroupList(user.uuid)).map((group) => {
-        return new GroupResDto(group);
-      }),
-    };
+    return this.groupService.getGroupList(user.uuid);
   }
 
   @ApiOperation({

--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -12,7 +12,6 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { GroupWithRole } from './types/groupWithRole';
 import { ExpandedGroup } from './types/ExpandedGroup.type';
 import { GroupWithUserRole } from './types/groupwithUserRole.type';
-import { GroupCreateResDto } from './dto/res/groupCreateRes.dto';
 
 @Injectable()
 export class GroupRepository {
@@ -181,7 +180,7 @@ export class GroupRepository {
     }: Pick<Group, 'name'> &
       Partial<Pick<Group, 'description' | 'notionPageId'>>,
     userUuid: string,
-  ): Promise<GroupCreateResDto> {
+  ): Promise<Group> {
     this.logger.log(`createGroup: ${name}`);
     return this.prismaService.group
       .create({


### PR DESCRIPTION
Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 그룹 관련 응답 DTO에 프로필 이미지 URL을 포함하는 새로운 속성 `profileImageUrl` 추가.
	- AWS S3 URL을 처리하는 새로운 속성 `s3Url` 추가.

- **버그 수정**
	- `GroupController`와 `GroupService`에서 응답 형식을 간소화하여 일관성 있는 데이터 반환.

- **문서화**
	- DTO 클래스의 생성자 및 반환 타입 업데이트로 인해 API 문서도 수정 필요.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->