### PR TITLE
[Feature] client가 등록한 authorites를 확인할 수 있는 api 만들기

### DIFF
--- a/src/client/client.controller.ts
+++ b/src/client/client.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   Param,
   Post,
   UseGuards,
@@ -27,12 +28,29 @@ import { ClientGuard } from './guard/client.guard';
 import { GetClient } from './decorator/getClient.decorator';
 import { Client } from '@prisma/client';
 import { AuthorityDto } from './dto/req/authority.dto';
+import { ExpandedClientResDto } from './dto/res/expandedClientRes.dto';
 
 @ApiTags('client')
 @Controller('client')
 @UsePipes(new ValidationPipe({ transform: true }))
 export class ClientController {
   constructor(private readonly clientService: ClientService) {}
+
+  @ApiOperation({
+    summary: 'Get clients',
+    description: 'Get clients with name and uuid',
+  })
+  @ApiOkResponse({
+    description: 'The clients have been successfully fetched.',
+    type: [ExpandedClientResDto],
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Unknown errors',
+  })
+  @Get(':uuid')
+  async getClient(@Param('uuid') uuid: string): Promise<ExpandedClientResDto> {
+    return this.clientService.getClient(uuid);
+  }
 
   @ApiOperation({
     summary: 'Register a new client',

--- a/src/client/client.repository.ts
+++ b/src/client/client.repository.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common';
 import { Client } from '@prisma/client';
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { ExpandedClient } from './types/ExpandedClient.type';
 
 @Injectable()
 @Loggable()
@@ -51,6 +52,18 @@ export class ClientRepository {
   async findByUuid(uuid: string): Promise<Client | null> {
     return this.prismaService.client.findUnique({
       where: { uuid },
+    });
+  }
+
+  /**
+   * Find a client by uuid with authorities. if the client is not found, return null
+   * @param uuid the uuid of the client to find
+   * @returns Founded client or null
+   */
+  async findByUuidWithAuthority(uuid: string): Promise<ExpandedClient | null> {
+    return this.prismaService.client.findUnique({
+      where: { uuid },
+      include: { ExternalAuthority: true },
     });
   }
 

--- a/src/client/client.service.ts
+++ b/src/client/client.service.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import { Loggable } from '@lib/logger/decorator/loggable';
+import { ExpandedClient } from './types/ExpandedClient.type';
 
 @Injectable()
 @Loggable()
@@ -21,6 +22,21 @@ export class ClientService {
   ) {
     this.SlACK_WEBHOOK_URL =
       this.configService.getOrThrow<string>('SLACK_WEBHOOK_URL');
+  }
+
+  /**
+   * get client
+   * @param uuid uuid of the client to get
+   * @returns client
+   */
+  async getClient(uuid: string): Promise<ExpandedClient> {
+    const client = await this.clientRepository.findByUuidWithAuthority(uuid);
+    if (!client) {
+      this.logger.debug(`client not found`);
+      throw new ForbiddenException('client not found');
+    }
+
+    return client;
   }
 
   /**

--- a/src/client/dto/res/expandedClientRes.dto.ts
+++ b/src/client/dto/res/expandedClientRes.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ClientResDto } from './clientRes.dto';
+import { ExternalAuthority } from '@prisma/client';
+
+class AuthorityResDto implements ExternalAuthority {
+  @ApiProperty()
+  clientUuid: string;
+
+  @ApiProperty()
+  authority: string;
+}
+
+export class ExpandedClientResDto extends ClientResDto {
+  @ApiProperty()
+  ExternalAuthority: AuthorityResDto[];
+}

--- a/src/client/types/ExpandedClient.type.ts
+++ b/src/client/types/ExpandedClient.type.ts
@@ -1,0 +1,7 @@
+import { Prisma } from '@prisma/client';
+
+export type ExpandedClient = Prisma.ClientGetPayload<{
+  include: {
+    ExternalAuthority: true;
+  };
+}>;


### PR DESCRIPTION
Fixes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- UUID로 클라이언트를 조회할 수 있는 새로운 GET 엔드포인트 추가.
	- 클라이언트 응답을 위한 확장된 데이터 전송 객체(DTO) 구조 도입.
	- 클라이언트와 관련된 외부 권한 정보를 포함하는 새로운 메서드 추가.

- **버그 수정**
	- 클라이언트가 발견되지 않을 경우의 오류 처리 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->