### PR TITLE
fix: prevent removal of group president

### DIFF
--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -231,6 +231,17 @@ export class GroupService {
         'You do not have permission to remove a member',
       );
     }
+
+    const groupInfo = await this.groupRepository.getGroupByUuid(uuid);
+
+    if (groupInfo.President.uuid === targetUuid) {
+      throw new ForbiddenException(
+        groupInfo.President.uuid === userUuid
+          ? 'You cannot remove yourself from the group'
+          : 'You cannot remove the president',
+      );
+    }
+
     await this.groupRepository.removeUserFromGroup(uuid, targetUuid);
   }
 


### PR DESCRIPTION
# Pull request

## 개요
그룹의 멤버를 삭제하는 기능에서
삭제하려는 멤버가 그룹의 president인 경우
해당 멤버를 삭제하지 못하도록 수정했습니다.

이는 president 본인이 본인을 삭제하려는 경우와
멤버 삭제 권한이 있는 다른 유저가 president 유저를 삭제하는 경우
이렇게 2가지 경우를 포함합니다.

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?
