### PR TITLE
feat: grant ziggle write, delete to group admin

### DIFF
--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -263,6 +263,20 @@ export class GroupRepository {
                   Authority.GROUP_UPDATE,
                   Authority.GROUP_DELETE,
                 ],
+                RoleExternalAuthority: {
+                  createMany: {
+                    data: [
+                      {
+                        clientUuid: '8df6f258-f096-4f56-9d1b-7701c7376efd',
+                        authority: 'WRITE',
+                      },
+                      {
+                        clientUuid: '8df6f258-f096-4f56-9d1b-7701c7376efd',
+                        authority: 'DELETE',
+                      },
+                    ],
+                  },
+                },
                 userRole: {
                   create: {
                     userUuid,

--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -266,6 +266,7 @@ export class GroupRepository {
                   Authority.GROUP_UPDATE,
                   Authority.GROUP_DELETE,
                 ],
+                // TODO: it's hard coded. this should be changed.
                 RoleExternalAuthority: {
                   createMany: {
                     data: ZIGGLE_AUTHORITIES.map((authority) => ({

--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -18,6 +18,9 @@ import { GetGroupByNameQueryDto } from './dto/req/getGroup.dto';
 import { Loggable } from '@lib/logger/decorator/loggable';
 import { PrismaService } from '@lib/prisma';
 
+const ZIGGLE_CLIENT_UUID = '8df6f258-f096-4f56-9d1b-7701c7376efd';
+const ZIGGLE_AUTHORITIES = ['WRITE', 'DELETE'] as const;
+
 @Injectable()
 @Loggable()
 export class GroupRepository {
@@ -265,16 +268,10 @@ export class GroupRepository {
                 ],
                 RoleExternalAuthority: {
                   createMany: {
-                    data: [
-                      {
-                        clientUuid: '8df6f258-f096-4f56-9d1b-7701c7376efd',
-                        authority: 'WRITE',
-                      },
-                      {
-                        clientUuid: '8df6f258-f096-4f56-9d1b-7701c7376efd',
-                        authority: 'DELETE',
-                      },
-                    ],
+                    data: ZIGGLE_AUTHORITIES.map((authority) => ({
+                      clientUuid: ZIGGLE_CLIENT_UUID,
+                      authority,
+                    })),
                   },
                 },
                 userRole: {


### PR DESCRIPTION
# Pull request

## 개요
새로 생성된 그룹의 어드민이 지글 공지를 작성할 수 없는 문제를 하드코딩으로 해결하였습니다
close #115

## PR Checklist

- [ ] 환경에 따른 실행 여부를 확인하였나요?
- [ ] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
  - 그룹 생성 시 외부 권한 관리 기능이 강화되어, 새 그룹에 'WRITE'와 'DELETE' 권한이 자동으로 추가됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->