### PR TITLE
[FEATURE] manager가 자신 보다 높은 roleId로 초대 링크 생성 차단하기

### DIFF
--- a/src/group/group.repository.ts
+++ b/src/group/group.repository.ts
@@ -394,6 +394,9 @@ export class GroupRepository {
         userUuid,
         groupUuid: uuid,
       },
+      orderBy: {
+        roleId: 'asc',
+      },
       select: {
         Role: true,
       },

--- a/src/group/group.service.ts
+++ b/src/group/group.service.ts
@@ -168,6 +168,12 @@ export class GroupService {
         'You do not have permission to create an invite code',
       );
     }
+    const role = await this.groupRepository.getUserRoleInGroup(uuid, userUuid);
+    if (role.id < roleId) {
+      throw new ForbiddenException(
+        'You do not have permission to grant a role higher than yours',
+      );
+    }
     const code = crypto
       .randomBytes(32)
       .toString('base64')


### PR DESCRIPTION
Fixes #121

# Pull request

## 개요
<!-- 어떤 이슈를 해결하였나요? -->
자신모다 더 큰 roleId에 대한 초대를 보내지 못하도록 바꿨습니다.

## PR Checklist

- [x] 환경에 따른 실행 여부를 확인하였나요?
- [x] 변경 내용에 관한 테스트를 진행하였나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
	- 그룹 내 역할이 오름차순으로 정렬되어 보다 예측 가능한 결과를 제공합니다.
	- 초대 코드 생성 시 사용자가 자신의 권한보다 높은 역할을 부여할 수 없도록 권한 검증 로직이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->